### PR TITLE
Fixing some minor typos and adding manage ACL and resource clean up

### DIFF
--- a/templates/fms-wafv2.yaml
+++ b/templates/fms-wafv2.yaml
@@ -20,6 +20,12 @@ Parameters:
       - Org
       - OU
       - Accounts
+  optimizeUnassociatedWebACLValue:
+    Type: String
+    Description: "Should Firewall Manager manage unassociated web ACLs? if True Firewall Manager creates web ACLs in the accounts within policy scope only if the web ACLs will be used by at least one resource"
+    AllowedValues:
+      - True
+      - False
   ResourceTagUsage:
     Type: String
     Default: Include
@@ -27,6 +33,12 @@ Parameters:
     AllowedValues:
       - Include
       - Exclude
+  ResourcesCleanUpFlag:
+    Type: String
+    Description: "Should Firewall Manager automatically remove protections from resources that leave the policy scope? (Not valid for Shield Advanced)"
+    AllowedValues:
+      - True
+      - False
   WAFv2ProtectRegionalResourceTypes:
     Type: String
     Default: AWS::ApiGateway::Stage,AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -154,6 +166,7 @@ Resources:
         ACCOUNT:
           !If [ExcludeScopeFlag, !If [AccountScopeFlag,  !Split [",", !Ref ScopeDetails], !Ref "AWS::NoValue"], !Ref "AWS::NoValue"]
       RemediationEnabled: !If [AutoRemediateFlag, True, False]
+      ResourcesCleanUp: !Ref ResourcesCleanUpFlag
       DeleteAllPolicyResources: False
       ResourceTags:
         !If
@@ -179,7 +192,7 @@ Resources:
       SecurityServicePolicyData:
         Type: WAFV2
         ManagedServiceData: !Sub
-          - '{"type": "WAFV2", "preProcessRuleGroups":[{"ruleGroupArn": "${RateLimitRGArn}", "overrideAction": {"type": "NONE"}, "ruleGroupType":"RuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName":"AWSManagedRulesAmazonIpReputationList"}, "overrideAction": {"type": "${IPReputationActionValue}"},"ruleGroupType": "ManagedRuleGroup", "excludeRules":[], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesAnonymousIpList"},"overrideAction": {"type": "${AnonymousIPActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesKnownBadInputsRuleSet"}, "overrideAction": {"type": "${KnownBadInputsActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesCommonRuleSet"}, "overrideAction": {"type": "${CoreRuleSetActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}],"postProcessRuleGroups": [], "defaultAction": {"type": "ALLOW"}, "overrideCustomerWebACLAssociation": ${AutoRemediateForceValue}, "sampledRequestsEnabledForDefaultActions": true,"loggingConfiguration": {"redactedFields": [],"logDestinationConfigs": ["${FirehoseArn}"]}}'
+          - '{"type": "WAFV2", "preProcessRuleGroups":[{"ruleGroupArn": "${RateLimitRGArn}", "overrideAction": {"type": "NONE"}, "ruleGroupType":"RuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName":"AWSManagedRulesAmazonIpReputationList"}, "overrideAction": {"type": "${IPReputationActionValue}"},"ruleGroupType": "ManagedRuleGroup", "excludeRules":[], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesAnonymousIpList"},"overrideAction": {"type": "${AnonymousIPActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesKnownBadInputsRuleSet"}, "overrideAction": {"type": "${KnownBadInputsActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesCommonRuleSet"}, "overrideAction": {"type": "${CoreRuleSetActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}],"postProcessRuleGroups": [], "defaultAction": {"type": "ALLOW"}, "overrideCustomerWebACLAssociation": ${AutoRemediateForceValue}, "sampledRequestsEnabledForDefaultActions": true,"loggingConfiguration": {"redactedFields": [],"logDestinationConfigs": ["${FirehoseArn}"]}, "optimizeUnassociatedWebACL": ${optimizeUnassociatedWebACLValue}}'
           - RateLimitRGArn: !GetAtt RegionalRateLimitRuleGroup.Arn
             IPReputationActionValue: !If [IPReputationAMRActionFlag, 'NONE','COUNT']
             AnonymousIPActionValue: !If [AnonymousIPAMRActionFlag, 'NONE','COUNT']
@@ -208,6 +221,7 @@ Resources:
         ACCOUNT:
           !If [ExcludeScopeFlag, !If [AccountScopeFlag,  !Split [",", !Ref ScopeDetails], !Ref "AWS::NoValue"], !Ref "AWS::NoValue"]
       RemediationEnabled: !If [AutoRemediateFlag, true, false]
+      ResourcesCleanUp: !Ref ResourcesCleanUpFlag
       DeleteAllPolicyResources: false
       ResourceTags:
         !If
@@ -233,7 +247,7 @@ Resources:
       SecurityServicePolicyData:
         Type: WAFV2
         ManagedServiceData: !Sub
-          - '{"type": "WAFV2", "preProcessRuleGroups":[{"ruleGroupArn": "${RateLimitRGArn}", "overrideAction": {"type": "NONE"}, "ruleGroupType":"RuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName":"AWSManagedRulesAmazonIpReputationList"}, "overrideAction": {"type": "${IPReputationActionValue}"},"ruleGroupType": "ManagedRuleGroup", "excludeRules":[], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesAnonymousIpList"},"overrideAction": {"type": "${AnonymousIPActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesKnownBadInputsRuleSet"}, "overrideAction": {"type": "${KnownBadInputsActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesCommonRuleSet"}, "overrideAction": {"type": "${CoreRuleSetActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}],"postProcessRuleGroups": [], "defaultAction": {"type": "ALLOW"}, "overrideCustomerWebACLAssociation": ${AutoRemediateForceValue}, "sampledRequestsEnabledForDefaultActions": true,"loggingConfiguration": {"redactedFields": [],"logDestinationConfigs": ["${FirehoseArn}"]}}'
+          - '{"type": "WAFV2", "preProcessRuleGroups":[{"ruleGroupArn": "${RateLimitRGArn}", "overrideAction": {"type": "NONE"}, "ruleGroupType":"RuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName":"AWSManagedRulesAmazonIpReputationList"}, "overrideAction": {"type": "${IPReputationActionValue}"},"ruleGroupType": "ManagedRuleGroup", "excludeRules":[], "sampledRequestsEnabled": true}, {"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesAnonymousIpList"},"overrideAction": {"type": "${AnonymousIPActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesKnownBadInputsRuleSet"}, "overrideAction": {"type": "${KnownBadInputsActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true},{"managedRuleGroupIdentifier": {"vendorName": "AWS", "managedRuleGroupName": "AWSManagedRulesCommonRuleSet"}, "overrideAction": {"type": "${CoreRuleSetActionValue}"}, "ruleGroupType": "ManagedRuleGroup", "excludeRules": [], "sampledRequestsEnabled": true}],"postProcessRuleGroups": [], "defaultAction": {"type": "ALLOW"}, "overrideCustomerWebACLAssociation": ${AutoRemediateForceValue}, "sampledRequestsEnabledForDefaultActions": true,"loggingConfiguration": {"redactedFields": [],"logDestinationConfigs": ["${FirehoseArn}"]}, "optimizeUnassociatedWebACL": ${optimizeUnassociatedWebACLValue}}'
           - RateLimitRGArn: !GetAtt CloudFrontRateLimitRuleGroup.Arn
             IPReputationActionValue: !If [IPReputationAMRActionFlag, 'NONE','COUNT']
             AnonymousIPActionValue: !If [AnonymousIPAMRActionFlag, 'NONE','COUNT']

--- a/templates/s3iam.yaml
+++ b/templates/s3iam.yaml
@@ -149,8 +149,8 @@ Resources:
               kms:ViaService: !Sub "s3.${AWS::Region}.amazonaws.com"
             StringLike:
               "kms:EncryptionContext:aws:s3:arn":
-                - !Sub "arn:aws:s3:::${WafLogsS3Bucket.Arn}/*"
-                - !Sub "arn:aws:s3:::${LoggingS3Bucket.Arn}/*"
+                - !Sub "arn:aws:s3:::${WafLogsS3Bucket}/*"
+                - !Sub "arn:aws:s3:::${LoggingS3Bucket}/*"
         - Effect: Allow
           Action:
             - "s3:AbortMultipartUpload"
@@ -159,11 +159,12 @@ Resources:
             - "s3:ListBucket"
             - "s3:ListBucketMultipartUploads"
             - "s3:PutObject"
+            - "s3:PutObjectAcl"
           Resource:
-            - !Sub "arn:aws:s3:::${WafLogsS3Bucket.Arn}"
-            - !Sub "arn:aws:s3:::${WafLogsS3Bucket.Arn}/*"
-            - !Sub "arn:aws:s3:::${LoggingS3Bucket.Arn}"
-            - !Sub "arn:aws:s3:::${LoggingS3Bucket.Arn}/*"
+            - !Sub "arn:aws:s3:::${WafLogsS3Bucket}"
+            - !Sub "arn:aws:s3:::${WafLogsS3Bucket}/*"
+            - !Sub "arn:aws:s3:::${LoggingS3Bucket}"
+            - !Sub "arn:aws:s3:::${LoggingS3Bucket}/*"
         - Effect: Allow
           Action:
             - "logs:PutLogEvents"

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -85,6 +85,10 @@ Metadata:
         default: What type(s) of global resources should have AWS WAF protection
       ResourceTagUsage:
         default: If scope tags are specified, are these tags what to include (in scope) or are exclude ( out of scope)
+      optimizeUnassociatedWebACLValue:
+        default: if you want Firewall Manager to manage unassociated web ACLs, then enable Manage unassociated web ACLs
+      ResourcesCleanUpFlag:
+        default: Indicates whether AWS Firewall Manager should automatically remove protections from resources that leave the policy scope.
       FMSAdministratorAccount:
         default: What is the FMS Administrator/delegated Administrator if not the local account
       ScopeDetails:
@@ -158,6 +162,11 @@ Metadata:
           - WAFv2ProtectCloudFront
           - ShieldAutoRemediate
           - WAFv2AutoRemediate
+      - Label:
+          default: "Firewall Manager policy options [Optional]"
+        Parameters:
+          - optimizeUnassociatedWebACLValue
+          - ResourcesCleanUpFlag
       - Label:
           default: "AWS WAF v2 Configuration [Optional]"
         Parameters:
@@ -373,6 +382,20 @@ Parameters:
     AllowedValues:
       - Include
       - Exclude
+  optimizeUnassociatedWebACLValue:
+    Type: String
+    Default: False
+    Description: "Should Firewall Manager manage unassociated web ACLs? if True Firewall Manager creates web ACLs in the accounts within policy scope only if the web ACLs will be used by at least one resource"
+    AllowedValues:
+      - True
+      - False
+  ResourcesCleanUpFlag:
+    Type: String
+    Default: False
+    Description: "Should Firewall Manager automatically remove protections from resources that leave the policy scope? (Not valid for Shield Advanced)"
+    AllowedValues:
+      - True
+      - False
   ProtectRegionalResourceTypes:
     Type: String
     Description: Application Load Balancers | Classic Load Balancers | EIPs
@@ -710,6 +733,8 @@ Resources:
           ParameterValue: !Ref "ScopeType"
         - ParameterKey: ResourceTagUsage
           ParameterValue: !Ref "ResourceTagUsage"
+        - ParameterKey: optimizeUnassociatedWebACLValue
+          ParameterValue: !Ref "optimizeUnassociatedWebACLValue"
         - ParameterKey: ProtectRegionalResourceTypes
           ParameterValue: !Ref "ProtectRegionalResourceTypes"
         - ParameterKey: ProtectCloudFront
@@ -787,6 +812,10 @@ Resources:
           ParameterValue: !Ref "ScopeType"
         - ParameterKey: ResourceTagUsage
           ParameterValue: !Ref "ResourceTagUsage"
+        - ParameterKey: optimizeUnassociatedWebACLValue
+          ParameterValue: !Ref "optimizeUnassociatedWebACLValue"
+        - ParameterKey: ResourcesCleanUpFlag
+          ParameterValue: !Ref "ResourcesCleanUpFlag"
         - ParameterKey: WAFv2ProtectRegionalResourceTypes
           ParameterValue: !Ref "WAFv2ProtectRegionalResourceTypes"
         - ParameterKey: WAFv2ProtectCloudFront


### PR DESCRIPTION


*Fix S3 ARN:* S3 ARN was duplicated on WAF policy.

*Add optimizeUnassociatedWebACL option:* Enable Web ACL management, Firewall Manager creates web ACLs in the accounts within policy scope only if the web ACLs will be used by at least one resource.

*Add ResourcesCleanUp option:* when using TAGs the current configuration is not removing protection from resources that leave the policy scope. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
